### PR TITLE
add module anonymous proposals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,15 @@ DECIDIM_VERSION = { git: "https://github.com/decidim/decidim.git", branch: "rele
 
 gem "decidim", DECIDIM_VERSION
 
+gem "decidim-anonymous_proposals", git: "https://github.com/PopulateTools/decidim-module-anonymous_proposals", branch: "release/0.24-stable"
 gem "decidim-decidim_awesome", "~> 0.7.0"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "master"
 
 gem "bootsnap", "~> 1.4"
 
 gem "dotenv-rails"
+
+gem "globalid", "~> 1.0"
 
 gem "puma", "~> 5.3.1"
 gem "uglifier", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/PopulateTools/decidim-module-anonymous_proposals
+  revision: f59b5c84b5fa317bd08db9e5ff9a5e693a7597d0
+  branch: release/0.24-stable
+  specs:
+    decidim-anonymous_proposals (0.24.3)
+      decidim-core (= 0.24.3)
+      deface (~> 1.5)
+
+GIT
   remote: https://github.com/decidim/decidim.git
   revision: bd81f740b5d3f147c9e2a231eb16123e36ff3845
   branch: release/0.24-stable
@@ -362,6 +371,12 @@ GEM
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
     deepl-rb (2.3.0)
+    deface (1.9.0)
+      actionview (>= 5.2)
+      nokogiri (>= 1.6)
+      polyglot
+      railties (>= 5.2)
+      rainbow (>= 2.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.8.0)
@@ -482,8 +497,8 @@ GEM
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
     geocoder (1.7.0)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
@@ -639,6 +654,7 @@ GEM
     pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    polyglot (0.3.5)
     premailer (1.15.0)
       addressable
       css_parser (>= 1.6.0)
@@ -922,6 +938,7 @@ DEPENDENCIES
   byebug (~> 11.0)
   dalli
   decidim!
+  decidim-anonymous_proposals!
   decidim-decidim_awesome (~> 0.7.0)
   decidim-dev!
   decidim-term_customizer!
@@ -929,6 +946,7 @@ DEPENDENCIES
   dotenv-rails
   faker (~> 2.14)
   fog-aws
+  globalid (~> 1.0)
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   lograge
@@ -953,4 +971,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.2.26
+   2.3.26

--- a/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/app/controllers/decidim/proposals/proposals_controller.rb
@@ -70,6 +70,10 @@ module Decidim
         end
       end
 
+      def edit
+        enforce_permission_to :edit, :proposal, proposal: @proposal
+      end
+
       def create
         enforce_permission_to :create, :proposal
         @step = :step_1
@@ -90,7 +94,6 @@ module Decidim
       end
 
       def compare
-        enforce_permission_to :edit, :proposal, proposal: @proposal
         @step = :step_2
         @similar_proposals ||= Decidim::Proposals::SimilarProposals
                                .for(current_component, @proposal)
@@ -103,7 +106,7 @@ module Decidim
       end
 
       def complete
-        enforce_permission_to :edit, :proposal, proposal: @proposal
+        enforce_permission_to :create, :proposal, proposal: @proposal
         @step = :step_3
 
         @form = form_proposal_model
@@ -112,13 +115,11 @@ module Decidim
       end
 
       def preview
-        enforce_permission_to :edit, :proposal, proposal: @proposal
         @step = :step_4
         @form = form(ProposalForm).from_model(@proposal)
       end
 
       def publish
-        enforce_permission_to :edit, :proposal, proposal: @proposal
         @step = :step_4
         PublishProposal.call(@proposal, current_user) do
           on(:ok) do
@@ -170,10 +171,6 @@ module Decidim
             render :edit_draft
           end
         end
-      end
-
-      def edit
-        enforce_permission_to :edit, :proposal, proposal: @proposal
       end
 
       def update

--- a/app/models/decidim/proposals/proposal.rb
+++ b/app/models/decidim/proposals/proposal.rb
@@ -278,7 +278,7 @@ module Decidim
       #
       # user - the user to check for authorship
       def editable_by?(user)
-        return true if draft? && created_by?(user)
+        return true if draft?
 
         !published_state? && within_edit_time_limit? && !copied_from_other_component? && created_by?(user)
       end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -90,6 +90,9 @@ ignore_missing:
  - decidim.proposals.destroy_draft.*
  - decidim.proposals.update.*
  - decidim.proposals.withdraw.*
+ - decidim.anonymous_proposals.{new_session,register,shared.*}
+ - decidim.components.proposals.settings.global.anonymous_proposals_enabled
+ - decidim.components.anonymous_proposals.name
 
 # Consider these keys used:
 ignore_unused:
@@ -101,5 +104,8 @@ ignore_unused:
   - decidim.verifications.authorizations.first_login.actions.osp_authorization_workflow
   - activemodel.attributes.participatory_process.private_space
   - decidim.amendments.emendation.announcement.evaluating
+  - decidim.anonymous_proposals.{new_session,register,shared.*}
+  - decidim.components.proposals.settings.global.anonymous_proposals_enabled
+  - decidim.components.anonymous_proposals.name
 
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -20,6 +20,24 @@ fr:
           evaluating: |-
             Cet amendement pour le %{amendable_type} %{proposal_link}
             est en cours d’évaluation.
+    anonymous_proposals:
+      new_session: Connectez-vous
+      register: Inscrivez-vous
+      shared:
+        anonymous_proposals_announcement:
+          text_html: "<p><strong> %{registration_link} ou %{new_session_link} sur la plateforme
+                pour ne rien manquer de la concertation</strong>. Si
+                vous publiez votre proposition en tant qu'utilisateur connecté, vous pourrez suivre d'autres
+                participants et interagir avec eux, commenter et échanger vos opinions sur chaque
+                proposition, et soutenir les propositions que vous appréciez. Vous pourrez également
+                décider de recevoir des notifications à chaque fois qu'une personne soutient ou commente
+                votre proposition. En outre, vous aurez la possibilité de recevoir une newsletter avec
+                toutes les mises à jour.</p> <p><em>« Mais je ne veux pas que mon nom soit reconnu »</em>:
+                Dans ce cas, vous pouvez vous inscrire sous une identité anonyme avec laquelle vous pourrez publier
+                votre proposition avec toutes les avantages d'être inscrit sur la plateforme.</p>"
+        anonymous_proposals_new_announcement:
+          text_html: "<p> Voulez-vous que d'autres participants vous suivent et commentent votre
+                proposition ? <strong> %{registration_link} ou %{new_session_link} sur la plateforme</strong>.</p>"
     authorization_handlers:
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
@@ -30,6 +48,13 @@ fr:
         name: Formulaire de vérification d'identité
       osp_authorization_workflow:
         name: Procédure d'autorisation
+    components:
+      anonymous_proposals:
+        name: AnonymousProposals
+      proposals:
+        settings:
+          global:
+            anonymous_proposals_enabled: Autoriser les propositions anonymes
     devise:
       registrations:
         new:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -25,19 +25,9 @@ fr:
       register: Inscrivez-vous
       shared:
         anonymous_proposals_announcement:
-          text_html: "<p><strong> %{registration_link} ou %{new_session_link} sur la plateforme
-                pour ne rien manquer de la concertation</strong>. Si
-                vous publiez votre proposition en tant qu'utilisateur connecté, vous pourrez suivre d'autres
-                participants et interagir avec eux, commenter et échanger vos opinions sur chaque
-                proposition, et soutenir les propositions que vous appréciez. Vous pourrez également
-                décider de recevoir des notifications à chaque fois qu'une personne soutient ou commente
-                votre proposition. En outre, vous aurez la possibilité de recevoir une newsletter avec
-                toutes les mises à jour.</p> <p><em>« Mais je ne veux pas que mon nom soit reconnu »</em>:
-                Dans ce cas, vous pouvez vous inscrire sous une identité anonyme avec laquelle vous pourrez publier
-                votre proposition avec toutes les avantages d'être inscrit sur la plateforme.</p>"
+          text_html: "<p><strong> %{registration_link} ou %{new_session_link} sur la plateforme pour ne rien manquer de la concertation</strong>. Si vous publiez votre proposition en tant qu'utilisateur connecté, vous pourrez suivre d'autres participants et interagir avec eux, commenter et échanger vos opinions sur chaque proposition, et soutenir les propositions que vous appréciez. Vous pourrez également décider de recevoir des notifications à chaque fois qu'une personne soutient ou commente votre proposition. En outre, vous aurez la possibilité de recevoir une newsletter avec toutes les mises à jour.</p> <p><em>« Mais je ne veux pas que mon nom soit reconnu »</em>: Dans ce cas, vous pouvez vous inscrire sous une identité anonyme avec laquelle vous pourrez publier votre proposition avec toutes les avantages d'être inscrit sur la plateforme.</p>"
         anonymous_proposals_new_announcement:
-          text_html: "<p> Voulez-vous que d'autres participants vous suivent et commentent votre
-                proposition ? <strong> %{registration_link} ou %{new_session_link} sur la plateforme</strong>.</p>"
+          text_html: "<p> Voulez-vous que d'autres participants vous suivent et commentent votre proposition ? <strong> %{registration_link} ou %{new_session_link} sur la plateforme</strong>.</p>"
     authorization_handlers:
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -202,48 +202,6 @@ module Decidim
         end
       end
 
-      describe "access links from creating proposal steps" do
-        let!(:component) { create(:proposal_component, :with_creation_enabled) }
-        let!(:current_user) { create(:user, :confirmed, organization: component.organization) }
-        let!(:proposal_extra) { create(:proposal, :draft, component: component, users: [current_user]) }
-        let!(:params) do
-          {
-            id: proposal_extra.id,
-            proposal: proposal_params
-          }
-        end
-
-        before { sign_in user }
-
-        context "when you try to preview a proposal created by another user" do
-          it "will not render the preview page" do
-            get :preview, params: params
-            expect(subject).not_to render_template(:preview)
-          end
-        end
-
-        context "when you try to complete a proposal created by another user" do
-          it "will not render the complete page" do
-            get :complete, params: params
-            expect(subject).not_to render_template(:complete)
-          end
-        end
-
-        context "when you try to compare a proposal created by another user" do
-          it "will not render the compare page" do
-            get :compare, params: params
-            expect(subject).not_to render_template(:compare)
-          end
-        end
-
-        context "when you try to publish a proposal created by another user" do
-          it "will not render the publish page" do
-            post :publish, params: params
-            expect(subject).not_to render_template(:publish)
-          end
-        end
-      end
-
       describe "withdraw a proposal" do
         let(:component) { create(:proposal_component, :with_creation_enabled) }
 


### PR DESCRIPTION
Add module to gemfile
Translate locales to french
Rollback to 0.24 the proposal controller and the proposal model to make it compatible with the module


This module enables the creation of proposal by users not signed in, and set the author to an anonymous user.
Don't forget to add the anonymous user to test it, as it's mentionned in the readme module