### PR TITLE
Avoid generating many images

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -116,7 +116,7 @@ jobs:
           namespace: ${{ vars.REGISTRY_NAMESPACE }}
           password: ${{ secrets.TOKEN }}
           image_name: ${{ vars.IMAGE_NAME }}
-          tag: "develop-${{ github.sha }}"
+          tag: "develop"
   generate_release:
     name: Generate release
     needs: [ lint, tests, test_build ]


### PR DESCRIPTION
#### :tophat: Description
If you use this build sequence, you'll see that it unfortunately generates a lot of images, which serves no purpose. This PR avoids this inflation.


### :camera: Screenshots
<img width="1170" alt="Capture d’écran 2023-06-13 à 12 46 43" src="https://github.com/OpenSourcePolitics/decidim-app/assets/20232956/1901955a-58b6-4e0d-a4cd-5526db8166e4">

