### PR TITLE
[Fix] - Add ruby-progress bar dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "nokogiri", "1.13.4"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "puma", ">= 5.5.1"
 gem "rack-attack", "~> 6.6"
+gem "ruby-progressbar"
 gem "sys-filesystem"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -907,6 +907,7 @@ DEPENDENCIES
   puma (>= 5.5.1)
   rack-attack (~> 6.6)
   rubocop-faker
+  ruby-progressbar
   sendgrid-ruby
   sentry-rails
   sentry-ruby


### PR DESCRIPTION
#### Description

Add `ruby-progressbar` dependency

#### Context 

CI is failing on Docker build because of missing required dependency