### PR TITLE
[Bump] - Use 6.0 default config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ Bundler.require(*Rails.groups)
 module DevelopmentApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
     config.time_zone = "Europe/Paris" unless Rails.env.test?
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml").to_s]
 


### PR DESCRIPTION
Use default param for 6.0 by default

previous params:

action_controller.per_form_csrf_tokens = true
action_controller.forgery_protection_origin_check = true
ActiveSupport.to_time_preserves_timezone = true
active_record.belongs_to_required_by_default = true
self.ssl_options = { hsts: { subdomains: true } }
assets.unknown_asset_fallback = false
action_view.form_with_generates_remote_forms = true
active_record.cache_versioning = true
action_dispatch.use_authenticated_cookie_encryption = true
active_support.use_authenticated_message_encryption = true
active_support.use_sha1_digests = true
action_controller.default_protect_from_forgery = true
action_view.form_with_generates_ids = true
new params:

action_controller.per_form_csrf_tokens = true
action_controller.forgery_protection_origin_check = true
ActiveSupport.to_time_preserves_timezone = true
active_record.belongs_to_required_by_default = true
self.ssl_options = { hsts: { subdomains: true } }
assets.unknown_asset_fallback = false
action_view.form_with_generates_remote_forms = true
active_record.cache_versioning = true
action_dispatch.use_authenticated_cookie_encryption = true
active_support.use_authenticated_message_encryption = true
active_support.use_sha1_digests = true
action_controller.default_protect_from_forgery = true
action_view.form_with_generates_ids = true
self.autoloader = :zeitwerk if RUBY_ENGINE == "ruby"
action_view.default_enforce_utf8 = false
action_dispatch.use_cookies_with_metadata = true
action_dispatch.return_only_media_type_on_content_type = false
action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
active_job.return_false_on_aborted_enqueue = true
active_storage.queues.analysis = :active_storage_analysis
active_storage.queues.purge = :active_storage_purge
active_storage.replace_on_assign_to_many = true
active_record.collection_cache_versioning = true
For backports:

run bin/rails zeitwerk:check